### PR TITLE
refactor to use ermrest entity_rid api

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,8 +271,8 @@ is configured:
     [
       "^(?P<KEY>[-0-9A-Za-z]+)$",
       "^(?P<KEY>[-0-9A-Za-z]+)@(?P<SNAP>[-0-9A-Za-z]+)$"
-      "^(?P<CAT>[^/]+/)(?P<KEY>[-0-9A-Za-z]+)$",
-      "^(?P<CAT>[^/]+/))(?P<KEY>[-0-9A-Za-z]+)@(?P<SNAP>[-0-9A-Za-z]+)$"
+      "^(?P<CAT>[^/@]+)/(?P<KEY>[-0-9A-Za-z]+)$",
+      "^(?P<CAT>[^/@]+)/)(?P<KEY>[-0-9A-Za-z]+)@(?P<SNAP>[-0-9A-Za-z]+)$"
     ]
 
 This default set of patterns can match:

--- a/README.md
+++ b/README.md
@@ -204,9 +204,9 @@ The configuration file has a top-level object with several fields:
    - `server_url`: the target base server URL (optional, defaults to
      global setting)
    - `catalog`: the target catalog identifier (optional)
-   - `schema`: the target schema name (optional)
-   - `table`: the target table name (optional)
-   - `column`: the target column name (optional)
+   - `schema`: legacy target schema name (optional)
+   - `table`: legacy target table name (optional)
+   - `column`: legacy target column name (optional)
 
 #### Catalog selection
 
@@ -250,7 +250,7 @@ and interprets them appropriately.
 
 #### Legacy resolution method
 
-When the `schema`, `table`, and `column` fields are all present with
+When the `schema`, `table`, and `column` fields are present with
 non-null values, ERMresolve is configured to use the `/entity/` API
 of the configured ERMrest catalog. This method generates GET requests
 on the following forms of ERMrest URL:
@@ -262,6 +262,9 @@ on the following forms of ERMrest URL:
 
 A non-empty result set is interpreted as successful resolution of
 the entity in the target table.
+
+A partial legacy configuration target is considered invalid and the
+service will abort with diagnostics in the HTTPD error log.
 
 #### Default patterns
 

--- a/ermresolve/config.py
+++ b/ermresolve/config.py
@@ -17,6 +17,7 @@
 
 import platform
 import os
+import os.path
 import json
 import re
 import urllib
@@ -143,5 +144,8 @@ def get_service_config(configfile=None):
     """Construct ERMresolve configuration objects from JSON configuration file."""
     if configfile is None:
         configfile = '%s/ermresolve_config.json' % os.environ.get('HOME', './')
-    with open(configfile) as f:
-        return ResolverConfig(json.load(f))
+    if os.path.exists(configfile) or os.path.islink(configfile):
+        with open(configfile) as f:
+            return ResolverConfig(json.load(f))
+    else:
+        return ResolverConfig({})

--- a/ermresolve/config.py
+++ b/ermresolve/config.py
@@ -56,12 +56,18 @@ class ResolverTarget (object):
         self.column = validate('column', column, [type(None)])
         self.legacy = self.schema is not None and self.table is not None and self.column is not None
 
-    def __str__(self):
-        return "ResolverTarget(%s, %s, %s, %s, %s, %s)" % self.astuple()
+        if not self.legacy:
+            missing = [ attr for attr in ["schema", "table", "column"] if getattr(self, attr) is None ]
+            if len(missing) < 3:
+                raise ValueError("Incomplete legacy target %s lacks %s configuration." % (self.astuple(False), "/".join(missing)))
 
-    def astuple(self):
-        return (
+    def __str__(self):
+        return "ResolverTarget%s" % (self.astuple(),)
+
+    def astuple(self, include_patterns=True):
+        return ((
             [ p.pattern for p in self.patterns ],
+        ) if include_patterns else ()) + (
             self.server_url,
             self.catalog,
             self.schema,


### PR DESCRIPTION
- Add support for the new resolution method via ERMrest entity_rid API
- Add support for `CAT` match group in patterns for embedded catalog IDs
- Adjust defaults for simpler out of box config:
   - Add patterns with catalog prefix e.g. `7/1-X140`
   - Add service-wide default catalog field alongside server URL
   - Allow empty target `{}` for default multi-tenant behavior
   - Allow missing config file for full default behavior
- Retain legacy table search intended for small number of cases
- Drop syntactic sugars since we no longer need to generate long lists of target tables